### PR TITLE
Remove unused containers to mitigate UI issue

### DIFF
--- a/llama2_chatbot.py
+++ b/llama2_chatbot.py
@@ -62,11 +62,7 @@ def render_app():
                 </style>
                 """
     st.markdown(hide_streamlit_style, unsafe_allow_html=True)
-
-    #container for the chat history
-    response_container = st.container()
-    #container for the user's text input
-    container = st.container()
+        
     #Set up/Initialize Session State variables:
     if 'chat_dialogue' not in st.session_state:
         st.session_state['chat_dialogue'] = []


### PR DESCRIPTION
This PR removes two unused containers which are causing some UI issues, as you can see here:

https://github.com/a16z-infra/llama2-chatbot/assets/2852129/6b5458bc-c073-4baf-94ed-81ea5f12ac76

The two empty containers cause the first two text elements to become duplicated & stale until the run has finished. This is caused by the rendering logic in the Streamlit frontend, which isn't super optimized yet for long-running reruns with dynamically growing UIs. Something we are working on improving.